### PR TITLE
Readme.md - Install instructions not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 To install the latest development version using `devtools`, type following in R:
 
 		require(devtools)
-		install_github('makeR', 'jbryer')
+		install_github("jbryer/makeR")
 
 The `rbloggers` demo provides a tour of the package.
 


### PR DESCRIPTION
Format of arguments when calling install_github() has changed.

This used to work, but doesn't any more. This is the newer format.